### PR TITLE
Add ingress nginx addon for metrics system

### DIFF
--- a/addons/ingress-nginx-metrics/README.md
+++ b/addons/ingress-nginx-metrics/README.md
@@ -1,0 +1,28 @@
+
+## Deployment
+### AWS
+```
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/kops/master/addons/ingress-nginx/v1.6.0.yaml
+```
+
+### GCE
+```
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/kops/master/addons/ingress-nginx/v1.6.0-gce.yaml
+```
+
+## Creating a simple ingress
+
+```
+kubectl run echoheaders --image=k8s.gcr.io/echoserver:1.4 --replicas=1 --port=8080
+kubectl expose deployment echoheaders --port=80 --target-port=8080 --name=echoheaders-x
+kubectl expose deployment echoheaders --port=80 --target-port=8080 --name=echoheaders-y
+
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/contrib/master/ingress/controllers/nginx/examples/ingress.yaml
+
+kubectl get services ingress-nginx -owide
+
+NAME            CLUSTER-IP      EXTERNAL-IP                                                               PORT(S)          AGE       SELECTOR
+ingress-nginx   100.71.196.44   a29c28f4b8b0811e685cb0a924c5a8a1-1593015597.us-east-1.elb.amazonaws.com   80/TCP,443/TCP   13m       app=ingress-nginx
+
+curl -v -H "Host: bar.baz.com" http://a29c28f4b8b0811e685cb0a924c5a8a1-1593015597.us-east-1.elb.amazonaws.com/bar
+```

--- a/addons/ingress-nginx-metrics/README.md
+++ b/addons/ingress-nginx-metrics/README.md
@@ -2,12 +2,12 @@
 ## Deployment
 ### AWS
 ```
-kubectl apply -f https://raw.githubusercontent.com/kubernetes/kops/master/addons/ingress-nginx/v1.6.0.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/kops/master/addons/ingress-nginx-metrics/v1.6.0.yaml
 ```
 
 ### GCE
 ```
-kubectl apply -f https://raw.githubusercontent.com/kubernetes/kops/master/addons/ingress-nginx/v1.6.0-gce.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/kops/master/addons/ingress-nginx-metrics/v1.6.0-gce.yaml
 ```
 
 ## Creating a simple ingress

--- a/addons/ingress-nginx-metrics/addon.yaml
+++ b/addons/ingress-nginx-metrics/addon.yaml
@@ -1,0 +1,13 @@
+kind: Addons
+metadata:
+  name: ingress-nginx
+spec:
+  addons:
+  - version: 1.4.0
+    selector:
+      k8s-addon: ingress-nginx.addons.k8s.io
+    manifest: v1.4.0.yaml
+  - version: 1.6.0
+    selector:
+      k8s-addon: ingress-nginx.addons.k8s.io
+    manifest: v1.6.0.yaml

--- a/addons/ingress-nginx-metrics/v1.4.0.yaml
+++ b/addons/ingress-nginx-metrics/v1.4.0.yaml
@@ -1,0 +1,133 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: nginx-default-backend
+  labels:
+    k8s-addon: ingress-nginx.addons.k8s.io
+spec:
+  ports:
+  - port: 80
+    targetPort: http
+  selector:
+    app: nginx-default-backend
+
+---
+
+kind: Deployment
+apiVersion: extensions/v1beta1
+metadata:
+  name: nginx-default-backend
+  labels:
+    k8s-addon: ingress-nginx.addons.k8s.io
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        k8s-addon: ingress-nginx.addons.k8s.io
+        app: nginx-default-backend
+    spec:
+      terminationGracePeriodSeconds: 60
+      containers:
+      - name: default-http-backend
+        image: k8s.gcr.io/defaultbackend:1.0
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 30
+          timeoutSeconds: 5
+        resources:
+          limits:
+            cpu: 10m
+            memory: 20Mi
+          requests:
+            cpu: 10m
+            memory: 20Mi
+        ports:
+        - name: http
+          containerPort: 8080
+          protocol: TCP
+
+---
+
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: ingress-nginx
+  labels:
+    k8s-addon: ingress-nginx.addons.k8s.io
+data:
+  use-proxy-protocol: "true"
+
+---
+
+kind: Service
+apiVersion: v1
+metadata:
+  name: ingress-nginx
+  labels:
+    k8s-addon: ingress-nginx.addons.k8s.io
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: '*'
+spec:
+  type: LoadBalancer
+  selector:
+    app: ingress-nginx
+  ports:
+  - name: http
+    port: 80
+    targetPort: http
+  - name: https
+    port: 443
+    targetPort: https
+
+---
+
+kind: Deployment
+apiVersion: extensions/v1beta1
+metadata:
+  name: ingress-nginx
+  labels:
+    k8s-addon: ingress-nginx.addons.k8s.io
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: ingress-nginx
+        k8s-addon: ingress-nginx.addons.k8s.io
+    spec:
+      terminationGracePeriodSeconds: 60
+      containers:
+      - image: k8s.gcr.io/nginx-ingress-controller:0.8.3
+        name: ingress-nginx
+        imagePullPolicy: Always
+        ports:
+          - name: http
+            containerPort: 80
+            protocol: TCP
+          - name: https
+            containerPort: 443
+            protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 10254
+            scheme: HTTP
+          initialDelaySeconds: 30
+          timeoutSeconds: 5
+        env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+        args:
+        - /nginx-ingress-controller
+        - --default-backend-service=$(POD_NAMESPACE)/nginx-default-backend
+        - --nginx-configmap=$(POD_NAMESPACE)/ingress-nginx

--- a/addons/ingress-nginx-metrics/v1.4.0.yaml
+++ b/addons/ingress-nginx-metrics/v1.4.0.yaml
@@ -59,7 +59,10 @@ metadata:
   labels:
     k8s-addon: ingress-nginx.addons.k8s.io
 data:
-  use-proxy-protocol: "true"
+  use-proxy-protocol: "false"
+  client-body-buffer-size: "16k"
+  proxy-connect-timeout: 60
+  proxy-body-size: "10m"
 
 ---
 

--- a/addons/ingress-nginx-metrics/v1.6.0-gce.yaml
+++ b/addons/ingress-nginx-metrics/v1.6.0-gce.yaml
@@ -1,0 +1,312 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kube-ingress
+  labels:
+    k8s-addon: ingress-nginx.addons.k8s.io
+
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nginx-ingress-controller
+  namespace: kube-ingress
+  labels:
+    k8s-addon: ingress-nginx.addons.k8s.io
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  labels:
+    k8s-addon: ingress-nginx.addons.k8s.io
+  name: nginx-ingress-controller
+  namespace: kube-ingress
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - endpoints
+      - nodes
+      - pods
+      - secrets
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "extensions"
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+        - events
+    verbs:
+        - create
+        - patch
+  - apiGroups:
+      - "extensions"
+    resources:
+      - ingresses/status
+    verbs:
+      - update
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  labels:
+    k8s-addon: ingress-nginx.addons.k8s.io
+  name: nginx-ingress-controller
+  namespace: kube-ingress
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - pods
+      - secrets
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    resourceNames:
+      # Defaults to "<election-id>-<ingress-class>"
+      # Here: "<ingress-controller-leader>-<nginx>"
+      # This has to be adapted if you change either parameter
+      # when launching the nginx-ingress-controller.
+      - "ingress-controller-leader-nginx"
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - endpoints
+    verbs:
+      - get
+      - create
+      - update
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    k8s-addon: ingress-nginx.addons.k8s.io
+  name: nginx-ingress-controller
+  namespace: kube-ingress
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: nginx-ingress-controller
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: system:serviceaccount:kube-ingress:nginx-ingress-controller
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  labels:
+    k8s-addon: ingress-nginx.addons.k8s.io
+  name: nginx-ingress-controller
+  namespace: kube-ingress
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: nginx-ingress-controller
+subjects:
+  - kind: ServiceAccount
+    name: nginx-ingress-controller
+    namespace: kube-ingress
+
+---
+
+kind: Service
+apiVersion: v1
+metadata:
+  name: nginx-default-backend
+  namespace: kube-ingress
+  labels:
+    k8s-app: default-http-backend
+    k8s-addon: ingress-nginx.addons.k8s.io
+spec:
+  ports:
+  - port: 80
+    targetPort: http
+  selector:
+    app: nginx-default-backend
+
+---
+
+kind: Deployment
+apiVersion: extensions/v1beta1
+metadata:
+  name: nginx-default-backend
+  namespace: kube-ingress
+  labels:
+    k8s-app: default-http-backend
+    k8s-addon: ingress-nginx.addons.k8s.io
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  template:
+    metadata:
+      labels:
+        k8s-app: default-http-backend
+        k8s-addon: ingress-nginx.addons.k8s.io
+        app: nginx-default-backend
+    spec:
+      terminationGracePeriodSeconds: 60
+      containers:
+      - name: default-http-backend
+        image: k8s.gcr.io/defaultbackend:1.4
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 30
+          timeoutSeconds: 5
+        resources:
+          limits:
+            cpu: 10m
+            memory: 20Mi
+          requests:
+            cpu: 10m
+            memory: 20Mi
+        ports:
+        - name: http
+          containerPort: 8080
+          protocol: TCP
+
+---
+
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: ingress-nginx
+  namespace: kube-ingress
+  labels:
+    k8s-addon: ingress-nginx.addons.k8s.io
+data:
+  use-proxy-protocol: "false"
+
+---
+
+kind: Service
+apiVersion: v1
+metadata:
+  name: ingress-nginx
+  namespace: kube-ingress
+  labels:
+    k8s-addon: ingress-nginx.addons.k8s.io
+spec:
+  # Forces nodes without Service endpoints to remove themselves from the list of nodes eligible. See https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-type-loadbalancer
+  externalTrafficPolicy: Local
+  type: LoadBalancer
+  selector:
+    app: ingress-nginx
+  ports:
+  - name: http
+    port: 80
+    targetPort: http
+  - name: https
+    port: 443
+    targetPort: https
+
+---
+
+kind: Deployment
+apiVersion: extensions/v1beta1
+metadata:
+  name: ingress-nginx
+  namespace: kube-ingress
+  labels:
+    k8s-app: nginx-ingress-controller
+    k8s-addon: ingress-nginx.addons.k8s.io
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: ingress-nginx
+        k8s-app: nginx-ingress-controller
+        k8s-addon: ingress-nginx.addons.k8s.io
+      annotations:
+        prometheus.io/port: '10254'
+        prometheus.io/scrape: 'true'
+    spec:
+      terminationGracePeriodSeconds: 60
+      serviceAccountName: nginx-ingress-controller
+      containers:
+      - image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.18.0
+        name: nginx-ingress-controller
+        imagePullPolicy: Always
+        ports:
+          - name: http
+            containerPort: 80
+            protocol: TCP
+          - name: https
+            containerPort: 443
+            protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 10254
+            scheme: HTTP
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 10254
+            scheme: HTTP
+          initialDelaySeconds: 30
+          timeoutSeconds: 5
+        env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+        args:
+        - /nginx-ingress-controller
+        - --default-backend-service=$(POD_NAMESPACE)/nginx-default-backend
+        - --configmap=$(POD_NAMESPACE)/ingress-nginx
+        - --publish-service=$(POD_NAMESPACE)/ingress-nginx

--- a/addons/ingress-nginx-metrics/v1.6.0-gce.yaml
+++ b/addons/ingress-nginx-metrics/v1.6.0-gce.yaml
@@ -225,6 +225,9 @@ metadata:
     k8s-addon: ingress-nginx.addons.k8s.io
 data:
   use-proxy-protocol: "false"
+  client-body-buffer-size: "16k"
+  proxy-connect-timeout: 60
+  proxy-body-size: "10m"
 
 ---
 

--- a/addons/ingress-nginx-metrics/v1.6.0.yaml
+++ b/addons/ingress-nginx-metrics/v1.6.0.yaml
@@ -1,0 +1,326 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kube-ingress
+  labels:
+    k8s-addon: ingress-nginx.addons.k8s.io
+
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nginx-ingress-controller
+  namespace: kube-ingress
+  labels:
+    k8s-addon: ingress-nginx.addons.k8s.io
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  labels:
+    k8s-addon: ingress-nginx.addons.k8s.io
+  name: nginx-ingress-controller
+  namespace: kube-ingress
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - endpoints
+      - nodes
+      - pods
+      - secrets
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "extensions"
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+        - events
+    verbs:
+        - create
+        - patch
+  - apiGroups:
+      - "extensions"
+    resources:
+      - ingresses/status
+    verbs:
+      - update
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  labels:
+    k8s-addon: ingress-nginx.addons.k8s.io
+  name: nginx-ingress-controller
+  namespace: kube-ingress
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - pods
+      - secrets
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    resourceNames:
+      # Defaults to "<election-id>-<ingress-class>"
+      # Here: "<ingress-controller-leader>-<nginx>"
+      # This has to be adapted if you change either parameter
+      # when launching the nginx-ingress-controller.
+      - "ingress-controller-leader-nginx"
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - endpoints
+    verbs:
+      - get
+      - create
+      - update
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    k8s-addon: ingress-nginx.addons.k8s.io
+  name: nginx-ingress-controller
+  namespace: kube-ingress
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: nginx-ingress-controller
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: system:serviceaccount:kube-ingress:nginx-ingress-controller
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  labels:
+    k8s-addon: ingress-nginx.addons.k8s.io
+  name: nginx-ingress-controller
+  namespace: kube-ingress
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: nginx-ingress-controller
+subjects:
+  - kind: ServiceAccount
+    name: nginx-ingress-controller
+    namespace: kube-ingress
+
+---
+
+kind: Service
+apiVersion: v1
+metadata:
+  name: nginx-default-backend
+  namespace: kube-ingress
+  labels:
+    k8s-app: default-http-backend
+    k8s-addon: ingress-nginx.addons.k8s.io
+spec:
+  ports:
+  - port: 80
+    targetPort: http
+  selector:
+    app: nginx-default-backend
+
+---
+
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: nginx-default-backend
+  namespace: kube-ingress
+  labels:
+    k8s-app: default-http-backend
+    k8s-addon: ingress-nginx.addons.k8s.io
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx-default-backend
+  revisionHistoryLimit: 10
+  template:
+    metadata:
+      labels:
+        k8s-app: default-http-backend
+        k8s-addon: ingress-nginx.addons.k8s.io
+        app: nginx-default-backend
+    spec:
+      terminationGracePeriodSeconds: 60
+      containers:
+      - name: default-http-backend
+        image: k8s.gcr.io/defaultbackend:1.3
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 30
+          timeoutSeconds: 5
+        resources:
+          limits:
+            cpu: 10m
+            memory: 20Mi
+          requests:
+            cpu: 10m
+            memory: 20Mi
+        ports:
+        - name: http
+          containerPort: 8080
+          protocol: TCP
+
+---
+
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: ingress-nginx
+  namespace: kube-ingress
+  labels:
+    k8s-addon: ingress-nginx.addons.k8s.io
+data:
+  # use-proxy-protocol: "true"
+  use-proxy-protocol: "false"
+  client-body-timeout: "16k"
+  proxy-connect-timeout: 60
+  proxy-body-size: "10m"
+
+---
+
+kind: Service
+apiVersion: v1
+metadata:
+  name: ingress-nginx
+  namespace: kube-ingress
+  labels:
+    k8s-addon: ingress-nginx.addons.k8s.io
+    # annotations:
+    #   service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: '*'
+spec:
+  # type: LoadBalancer
+  type: NodePort
+  selector:
+    app: ingress-nginx
+  ports:
+  - name: http
+    port: 80
+    targetPort: http
+    nodePort: 30080
+  - name: https
+    port: 443
+    targetPort: https
+    nodePort: 30443
+
+---
+
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: ingress-nginx
+  namespace: kube-ingress
+  labels:
+    k8s-app: nginx-ingress-controller
+    k8s-addon: ingress-nginx.addons.k8s.io
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: ingress-nginx
+  template:
+    metadata:
+      labels:
+        app: ingress-nginx
+        k8s-app: nginx-ingress-controller
+        k8s-addon: ingress-nginx.addons.k8s.io
+      annotations:
+        prometheus.io/port: '10254'
+        prometheus.io/scrape: 'true'
+    spec:
+      terminationGracePeriodSeconds: 60
+      serviceAccountName: nginx-ingress-controller
+      containers:
+      - image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.12.0
+        name: nginx-ingress-controller
+        imagePullPolicy: Always
+        ports:
+          - name: http
+            containerPort: 80
+            protocol: TCP
+          - name: https
+            containerPort: 443
+            protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 10254
+            scheme: HTTP
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 10254
+            scheme: HTTP
+          initialDelaySeconds: 30
+          timeoutSeconds: 5
+        env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+        args:
+        - /nginx-ingress-controller
+        - --default-backend-service=$(POD_NAMESPACE)/nginx-default-backend
+        - --configmap=$(POD_NAMESPACE)/ingress-nginx
+        # - --publish-service=$(POD_NAMESPACE)/ingress-nginx
+        - --annotations-prefix=ingress.kubernetes.io

--- a/addons/ingress-nginx-metrics/v1.6.0.yaml
+++ b/addons/ingress-nginx-metrics/v1.6.0.yaml
@@ -229,7 +229,7 @@ metadata:
 data:
   # use-proxy-protocol: "true"
   use-proxy-protocol: "false"
-  client-body-timeout: "16k"
+  client-body-buffer-size: "16k"
   proxy-connect-timeout: 60
   proxy-body-size: "10m"
 


### PR DESCRIPTION
This addon changes the nginx config map to support "heavier" HTTP requests and avoid canceling requests when the proxied server takes more than 5 seconds to connect.
