### PR TITLE
Increase ingress-nginx proxy-buffer-size

### DIFF
--- a/addons/ingress-nginx/v1.6.0.yaml
+++ b/addons/ingress-nginx/v1.6.0.yaml
@@ -229,6 +229,7 @@ metadata:
 data:
   # use-proxy-protocol: "true" # NOTICE: custom change for Velocidi
   use-proxy-protocol: "false" # NOTICE: custom change for Velocidi
+  proxy-buffer-size: "8k" # NOTICE: custom change for Velocidi, to avoid 502 with large headers on response from some keycloak requests
 
 ---
 


### PR DESCRIPTION
This fixes some errors we were having on some requests from Keycloak, that were getting 502 responses due to headers response being too large.