### PR TITLE
Revert "Increase ingress-nginx proxy-buffer-size"

### DIFF
--- a/addons/ingress-nginx/v1.6.0.yaml
+++ b/addons/ingress-nginx/v1.6.0.yaml
@@ -229,7 +229,6 @@ metadata:
 data:
   # use-proxy-protocol: "true" # NOTICE: custom change for Velocidi
   use-proxy-protocol: "false" # NOTICE: custom change for Velocidi
-  proxy-buffer-size: "8k" # NOTICE: custom change for Velocidi, to avoid 502 with large headers on response from some keycloak requests
 
 ---
 


### PR DESCRIPTION
Reverts velocidi/kops#5

Prefer specific service overrides via https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/ instead of global overrides via configmap.