### PR TITLE
Bump ingress-nginx-controller to version 1.1

### DIFF
--- a/addons/ingress-nginx/addon.yaml
+++ b/addons/ingress-nginx/addon.yaml
@@ -7,12 +7,15 @@ spec:
     selector:
       k8s-addon: ingress-nginx.addons.k8s.io
     manifest: v1.4.0.yaml
+    kubernetesVersion: "<1.22.0"
   - version: 1.6.0
     selector:
       k8s-addon: ingress-nginx.addons.k8s.io
     manifest: v1.6.0.yaml
+    kubernetesVersion: "<1.22.0"
     # Generated using the official helm chart: ./generate-manifest
   - version: 2.0.0
     selector:
       k8s-addon: ingress-nginx.addons.k8s.io
     manifest: v2.0.0.yaml
+    kubernetesVersion: ">=1.22.0"

--- a/addons/ingress-nginx/addon.yaml
+++ b/addons/ingress-nginx/addon.yaml
@@ -11,3 +11,8 @@ spec:
     selector:
       k8s-addon: ingress-nginx.addons.k8s.io
     manifest: v1.6.0.yaml
+    # Generated using the official helm chart: ./generate-manifest
+  - version: 2.0.0
+    selector:
+      k8s-addon: ingress-nginx.addons.k8s.io
+    manifest: v2.0.0.yaml

--- a/addons/ingress-nginx/addon.yaml
+++ b/addons/ingress-nginx/addon.yaml
@@ -7,15 +7,15 @@ spec:
     selector:
       k8s-addon: ingress-nginx.addons.k8s.io
     manifest: v1.4.0.yaml
-    kubernetesVersion: "<1.22.0"
+    kubernetesVersion: "<1.21.0"
   - version: 1.6.0
     selector:
       k8s-addon: ingress-nginx.addons.k8s.io
     manifest: v1.6.0.yaml
-    kubernetesVersion: "<1.22.0"
+    kubernetesVersion: "<1.21.0"
     # Generated using the official helm chart: ./generate-manifest
   - version: 2.0.0
     selector:
       k8s-addon: ingress-nginx.addons.k8s.io
     manifest: v2.0.0.yaml
-    kubernetesVersion: ">=1.22.0"
+    kubernetesVersion: ">=1.21.0"

--- a/addons/ingress-nginx/generate-manifest.sh
+++ b/addons/ingress-nginx/generate-manifest.sh
@@ -30,6 +30,7 @@ controller:
     enabled: false
   config:
     enable-real-ip: true
+    use-forwarded-headers: true
 "
 
 echo "Adding ingress-nginx to chart repositories"

--- a/addons/ingress-nginx/generate-manifest.sh
+++ b/addons/ingress-nginx/generate-manifest.sh
@@ -1,0 +1,42 @@
+DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
+RELEASE_NAME=ingress-nginx
+NAMESPACE=ingress-nginx
+
+NAMESPACE_VAR="
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: $NAMESPACE
+  labels:
+    app.kubernetes.io/name: $RELEASE_NAME
+    app.kubernetes.io/instance: $RELEASE_NAME
+"
+
+SETTINGS="
+controller:
+  labels:
+    k8s-addon: ingress-nginx.addons.k8s.io
+  service:
+    type: NodePort
+    nodePorts:
+      http: 30080
+      https: 30443
+  admissionWebhooks:
+    enabled: false
+  ingressClassResource:
+    default: true
+  publishService:
+    enabled: false
+  config:
+    enable-real-ip: true
+"
+
+echo "Adding ingress-nginx to chart repositories"
+helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
+
+echo "Generating manifest"
+OUTPUT_FILE="${DIR}/v2.0.0.yaml"
+echo "$NAMESPACE_VAR" > "$OUTPUT_FILE"
+echo "$SETTINGS" | helm template $RELEASE_NAME ingress-nginx/ingress-nginx --namespace $NAMESPACE --values - | grep -v -i "helm" | tee -a "$OUTPUT_FILE"
+
+echo "Done"

--- a/addons/ingress-nginx/generate-manifest.sh
+++ b/addons/ingress-nginx/generate-manifest.sh
@@ -10,6 +10,7 @@ metadata:
   labels:
     app.kubernetes.io/name: $RELEASE_NAME
     app.kubernetes.io/instance: $RELEASE_NAME
+    k8s-addon: ingress-nginx.addons.k8s.io
 "
 
 SETTINGS="

--- a/addons/ingress-nginx/v2.0.0.yaml
+++ b/addons/ingress-nginx/v2.0.0.yaml
@@ -1,0 +1,381 @@
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ingress-nginx
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: ingress-nginx
+
+---
+# Source: ingress-nginx/templates/controller-serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/version: "1.1.0"
+    app.kubernetes.io/component: controller
+    k8s-addon: ingress-nginx.addons.k8s.io
+  name: ingress-nginx
+  namespace: ingress-nginx
+automountServiceAccountToken: true
+---
+# Source: ingress-nginx/templates/controller-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/version: "1.1.0"
+    app.kubernetes.io/component: controller
+    k8s-addon: ingress-nginx.addons.k8s.io
+  name: ingress-nginx-controller
+  namespace: ingress-nginx
+data:
+  allow-snippet-annotations: "true"
+  enable-real-ip: "true"
+---
+# Source: ingress-nginx/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/version: "1.1.0"
+    k8s-addon: ingress-nginx.addons.k8s.io
+  name: ingress-nginx
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - endpoints
+      - nodes
+      - pods
+      - secrets
+      - namespaces
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses/status
+    verbs:
+      - update
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
+---
+# Source: ingress-nginx/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/version: "1.1.0"
+    k8s-addon: ingress-nginx.addons.k8s.io
+  name: ingress-nginx
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ingress-nginx
+subjects:
+  - kind: ServiceAccount
+    name: ingress-nginx
+    namespace: "ingress-nginx"
+---
+# Source: ingress-nginx/templates/controller-role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/version: "1.1.0"
+    app.kubernetes.io/component: controller
+    k8s-addon: ingress-nginx.addons.k8s.io
+  name: ingress-nginx
+  namespace: ingress-nginx
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - pods
+      - secrets
+      - endpoints
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses/status
+    verbs:
+      - update
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    resourceNames:
+      - ingress-controller-leader
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+---
+# Source: ingress-nginx/templates/controller-rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/version: "1.1.0"
+    app.kubernetes.io/component: controller
+    k8s-addon: ingress-nginx.addons.k8s.io
+  name: ingress-nginx
+  namespace: ingress-nginx
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ingress-nginx
+subjects:
+  - kind: ServiceAccount
+    name: ingress-nginx
+    namespace: "ingress-nginx"
+---
+# Source: ingress-nginx/templates/controller-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/version: "1.1.0"
+    app.kubernetes.io/component: controller
+  name: ingress-nginx-controller
+  namespace: ingress-nginx
+spec:
+  type: NodePort
+  ipFamilyPolicy: SingleStack
+  ipFamilies: 
+    - IPv4
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: http
+      appProtocol: http
+      nodePort: 30080
+    - name: https
+      port: 443
+      protocol: TCP
+      targetPort: https
+      appProtocol: https
+      nodePort: 30443
+  selector:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/component: controller
+---
+# Source: ingress-nginx/templates/controller-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/version: "1.1.0"
+    app.kubernetes.io/component: controller
+    k8s-addon: ingress-nginx.addons.k8s.io
+  name: ingress-nginx-controller
+  namespace: ingress-nginx
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ingress-nginx
+      app.kubernetes.io/instance: ingress-nginx
+      app.kubernetes.io/component: controller
+  replicas: 1
+  revisionHistoryLimit: 10
+  minReadySeconds: 0
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ingress-nginx
+        app.kubernetes.io/instance: ingress-nginx
+        app.kubernetes.io/component: controller
+        k8s-addon: ingress-nginx.addons.k8s.io
+    spec:
+      dnsPolicy: ClusterFirst
+      containers:
+        - name: controller
+          image: "k8s.gcr.io/ingress-nginx/controller:v1.1.0@sha256:f766669fdcf3dc26347ed273a55e754b427eb4411ee075a53f30718b4499076a"
+          imagePullPolicy: IfNotPresent
+          lifecycle: 
+            preStop:
+              exec:
+                command:
+                - /wait-shutdown
+          args:
+            - /nginx-ingress-controller
+            - --election-id=ingress-controller-leader
+            - --controller-class=k8s.io/ingress-nginx
+            - --configmap=$(POD_NAMESPACE)/ingress-nginx-controller
+          securityContext: 
+            capabilities:
+              drop:
+              - ALL
+              add:
+              - NET_BIND_SERVICE
+            runAsUser: 101
+            allowPrivilegeEscalation: true
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: LD_PRELOAD
+              value: /usr/local/lib/libmimalloc.so
+          livenessProbe: 
+            failureThreshold: 5
+            httpGet:
+              path: /healthz
+              port: 10254
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe: 
+            failureThreshold: 3
+            httpGet:
+              path: /healthz
+              port: 10254
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+            - name: https
+              containerPort: 443
+              protocol: TCP
+          resources: 
+            requests:
+              cpu: 100m
+              memory: 90Mi
+      nodeSelector: 
+        kubernetes.io/os: linux
+      serviceAccountName: ingress-nginx
+      terminationGracePeriodSeconds: 300
+---
+# Source: ingress-nginx/templates/controller-ingressclass.yaml
+# We don't support namespaced ingressClass yet
+# So a ClusterRole and a ClusterRoleBinding is required
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/version: "1.1.0"
+    app.kubernetes.io/component: controller
+    k8s-addon: ingress-nginx.addons.k8s.io
+  name: nginx
+  annotations:
+    ingressclass.kubernetes.io/is-default-class: "true"
+spec:
+  controller: k8s.io/ingress-nginx

--- a/addons/ingress-nginx/v2.0.0.yaml
+++ b/addons/ingress-nginx/v2.0.0.yaml
@@ -38,6 +38,7 @@ metadata:
 data:
   allow-snippet-annotations: "true"
   enable-real-ip: "true"
+  use-forwarded-headers: "true"
 ---
 # Source: ingress-nginx/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/addons/ingress-nginx/v2.0.0.yaml
+++ b/addons/ingress-nginx/v2.0.0.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
+    k8s-addon: ingress-nginx.addons.k8s.io
 
 ---
 # Source: ingress-nginx/templates/controller-serviceaccount.yaml


### PR DESCRIPTION
This new manifest was generated from the official helm chart: https://github.com/kubernetes/ingress-nginx/tree/main/charts/ingress-nginx